### PR TITLE
Route the production home page to Design Studio

### DIFF
--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -1,6 +1,15 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  reactStrictMode: true
+  reactStrictMode: true,
+  async redirects() {
+    return [
+      {
+        source: "/",
+        destination: "/design",
+        permanent: false,
+      },
+    ];
+  },
 };
 
 module.exports = nextConfig;


### PR DESCRIPTION
## What changed

The production root now redirects to `/design`.

## Why

The legacy workspace UI on `/` calls endpoints intentionally blocked by public safe mode. Authenticated testers should land directly in the supported Design Studio flow instead of reaching a dead-end after Google Login.

## Validation

- frontend unit tests: 7 passed
- ESLint: no errors
- production build with `NEXT_PUBLIC_BACKEND_URL=https://api.3d.pulsai.app`: passed
- no paid model calls
