### PR TITLE
Prepare Pulsai 3D for OSS launch

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,61 @@
+name: Bug report
+description: Report a reproducible problem in Pulsai 3D
+title: "[Bug]: "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thank you. Remove API keys, private model data, emails, and customer information. Report security issues privately using SECURITY.md.
+  - type: textarea
+    id: goal
+    attributes:
+      label: What were you trying to do?
+      placeholder: I selected the wall hook and tried to change...
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      description: Give the smallest numbered sequence that reproduces the problem.
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected result
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual result
+    validations:
+      required: true
+  - type: input
+    id: revision
+    attributes:
+      label: Pulsai revision or release
+      description: A release number, commit hash, or "hosted alpha on YYYY-MM-DD".
+  - type: input
+    id: environment
+    attributes:
+      label: Environment
+      placeholder: macOS 15, Chrome 140, hosted alpha
+    validations:
+      required: true
+  - type: textarea
+    id: evidence
+    attributes:
+      label: Safe screenshots or logs
+      description: Remove secrets and private data. Do not upload customer CAD files publicly.
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Safety checks
+      options:
+        - label: I removed secrets, personal data, and private model content.
+          required: true
+        - label: This is not a security vulnerability.
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security vulnerability
+    url: https://github.com/gizmuf/voice-to-3d-print/security/advisories/new
+    about: Report vulnerabilities privately. Do not open a public issue.
+  - name: Ten-minute non-coder test
+    url: https://github.com/gizmuf/voice-to-3d-print/blob/main/docs/HELP_WITHOUT_CODING.md
+    about: Follow the simple hosted-alpha checklist before sharing feedback.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,37 @@
+name: Feature request
+description: Propose a user problem or workflow improvement
+title: "[Feature]: "
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: Describe the real workflow problem before suggesting a solution.
+    validations:
+      required: true
+  - type: textarea
+    id: workflow
+    attributes:
+      label: Example workflow
+      description: Who needs this, and what are they trying to make or export?
+    validations:
+      required: true
+  - type: textarea
+    id: outcome
+    attributes:
+      label: Useful outcome
+      description: What observable result would make the issue complete?
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+  - type: checkboxes
+    id: safety
+    attributes:
+      label: Safety
+      options:
+        - label: I did not include secrets, private model data, or customer information.
+          required: true

--- a/.github/ISSUE_TEMPLATE/user_feedback.yml
+++ b/.github/ISSUE_TEMPLATE/user_feedback.yml
@@ -1,0 +1,52 @@
+name: Non-coder feedback
+description: Share a real demo attempt without technical language
+title: "[Feedback]: "
+labels: ["question"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        You do not need to know CAD or code. Honest feedback about one real attempt is useful.
+  - type: textarea
+    id: goal
+    attributes:
+      label: What did you want to make or change?
+    validations:
+      required: true
+  - type: dropdown
+    id: model
+    attributes:
+      label: What did you start with?
+      options:
+        - Speaker grille
+        - Phone stand
+        - Pen holder
+        - Box
+        - Parametric template
+        - My own file
+        - Something else
+    validations:
+      required: true
+  - type: textarea
+    id: experience
+    attributes:
+      label: What happened?
+      description: Tell us where you succeeded, became confused, or stopped.
+    validations:
+      required: true
+  - type: textarea
+    id: improvement
+    attributes:
+      label: What one change would help most?
+  - type: input
+    id: environment
+    attributes:
+      label: Device and browser
+      placeholder: iPhone Safari, Mac Chrome, Windows Edge...
+  - type: checkboxes
+    id: privacy
+    attributes:
+      label: Privacy
+      options:
+        - label: I did not include provider keys, personal data, or private customer/model information.
+          required: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,14 @@
+## What changed
+
+
+## Why
+
+
+## Validation
+
+- [ ] I ran the relevant automated or manual checks.
+- [ ] CAD changes produced the intended geometry/artifact change and I checked the current preview.
+- [ ] I did not run paid provider calls without my own authorized key and explicit budget.
+- [ ] I did not include secrets, customer data, private models, or unlicensed assets.
+
+## Limitations or follow-up

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,34 @@
+# Changelog
+
+Notable public changes to Pulsai 3D are recorded here.
+
+## [Unreleased]
+
+## [0.1.0] - 2026-08-17
+
+### Added
+
+- Public AGPL-3.0-or-later source release with security and contribution docs.
+- Parametric build123d/OpenCascade Design Studio with starter models,
+  revisions, deterministic edits, and optional provider-backed chat.
+- STEP/STP and STL import paths plus STEP, STL, GLB, DXF, bundle, and optional
+  FDM G-code exports.
+- FDM/CNC manufacturability heuristics, printer profiles, and PrusaSlicer
+  integration.
+- Owner-scoped authentication, private artifacts, BYOK provider routing,
+  secret scanning, and public-safe defaults.
+- Linux CI covering backend, frontend, STT, security, and a free browser
+  CAD-to-print flow.
+
+### Known limitations
+
+- This is an alpha release and is not safety-certified for manufacturing.
+- Imported STEP feature trees and arbitrary STL meshes are not fully
+  reconstructable in every case.
+- AI and organic-mesh results vary by provider and may require a customer-owned
+  paid account.
+- Every exported model, printer profile, and G-code file requires independent
+  review.
+
+[Unreleased]: https://github.com/gizmuf/voice-to-3d-print/compare/v0.1.0...HEAD
+[0.1.0]: https://github.com/gizmuf/voice-to-3d-print/releases/tag/v0.1.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,15 +1,68 @@
-# Contributing
+# Contributing to Pulsai 3D
 
-Thank you for your interest in Pulsai 3D. Before the first public release, the
-maintainer is still finalizing the contribution and dual-licensing process.
+Thank you for helping make open, editable CAD easier to use. Contributions from
+makers, designers, technical writers, testers, and developers are welcome.
 
-Small bug reports and reproducible test cases are welcome. Do not submit source
-code copied from CAD viewers, model libraries, generated assets, or other
-projects unless its license is explicitly compatible and provenance is
-documented. Never include API keys, customer projects, production logs, or
-private QA media.
+## Ways to help
 
-Code contributions will require an explicit contributor agreement before they
-can be merged, so that the AGPL community edition and optional commercial
-licenses can be maintained consistently. The agreement and sign-off workflow
-will be published before external pull requests are accepted.
+- Try the [hosted alpha](https://3d.pulsai.app) and submit structured feedback.
+- Reproduce a bug and add the smallest safe test case.
+- Improve setup, CAD, printer, or user documentation.
+- Add or verify a printer profile with a focused test.
+- Work on an issue labeled
+  [`good first issue`](https://github.com/gizmuf/voice-to-3d-print/labels/good%20first%20issue).
+- Propose a larger feature after discussing its scope in an issue.
+
+Non-coders can use the
+[10-minute testing guide](docs/HELP_WITHOUT_CODING.md). A clear report from a
+real workflow is a meaningful open-source contribution.
+
+## Before you start
+
+1. Search existing issues and pull requests.
+2. For anything larger than a small fix, open or comment on an issue first.
+3. Keep the change focused on one problem.
+4. Do not run paid provider calls unless you are using your own authorized key
+   and have set a budget.
+
+Use the local setup in [`README.md`](README.md) or the detailed Linux runbook in
+[`docs/RUNBOOK_LINUX.md`](docs/RUNBOOK_LINUX.md).
+
+## Pull requests
+
+A good pull request:
+
+- explains the user problem and the chosen change;
+- includes tests or a reproducible manual check appropriate to the risk;
+- preserves the deterministic, no-paid-AI validation path;
+- does not mix unrelated cleanup or dependency upgrades;
+- updates documentation when behavior changes;
+- passes `git diff --check` and the relevant backend/frontend checks.
+
+For CAD changes, “done” means the geometry or artifact changed as intended, the
+revision/mesh evidence was updated, and the current preview was checked. A
+successful API response alone is not enough.
+
+## Data, secrets, and provenance
+
+Never include API keys, tokens, customer projects, production logs, private QA
+media, personal information, or non-public model files. Do not submit code or
+assets copied from CAD viewers, model libraries, generated datasets, or other
+projects unless the license is compatible and the provenance is documented.
+
+Report suspected vulnerabilities privately as described in
+[`SECURITY.md`](SECURITY.md), not in a public issue.
+
+## Contribution licensing
+
+Unless a separate written agreement says otherwise, contributions accepted into
+this repository are provided under the repository's
+**AGPL-3.0-or-later** license. Commercial licensing of maintainer-owned code is
+separate; contributor work is not relicensed without the contributor's
+permission or another applicable agreement.
+
+The project may introduce an explicit contributor agreement for future changes
+that need dual-licensing rights. If that happens, the requirement will be stated
+before such a contribution is merged.
+
+By participating, you agree to follow [`CODE_OF_CONDUCT.md`](CODE_OF_CONDUCT.md).

--- a/README.md
+++ b/README.md
@@ -1,327 +1,179 @@
-# Pulsai 3D Stack
+# Pulsai 3D
 
-[![License: AGPL v3 or later](https://img.shields.io/badge/License-AGPL_v3_or_later-blue.svg)](LICENSE)
+**Open-source, AI-first parametric CAD for turning an idea into an editable
+model and manufacturing files.**
 
-Pulsai 3D is an AI-first, CAD-first design studio: describe or show a part,
-inspect the editable model, refine it through chat, voice, parameters, or
-selection, then validate and prepare it for manufacturing. The source of truth
-is build123d/OpenCascade CAD and its revisions; GLB/STL are derived artifacts.
+[![CI](https://github.com/gizmuf/voice-to-3d-print/actions/workflows/ci.yml/badge.svg)](https://github.com/gizmuf/voice-to-3d-print/actions/workflows/ci.yml)
+[![Release](https://img.shields.io/github/v/release/gizmuf/voice-to-3d-print?include_prereleases)](https://github.com/gizmuf/voice-to-3d-print/releases)
+[![License: AGPL-3.0-or-later](https://img.shields.io/badge/License-AGPL--3.0--or--later-blue.svg)](LICENSE)
 
-## Stack
-- **Frontend:** Next.js, React, Three.js / React Three Fiber, and drei.
-- **CAD:** build123d/OpenCascade and CadQuery, with audited Python source,
-  parameter snapshots, named features, revisions, and STEP-first exports.
-- **AI:** deterministic local edits first; Anthropic agent for ambiguous or
-  structural CAD work. Customer BYOK is supported and platform-paid AI is
-  disabled by default.
-- **Mesh / manufacturing:** trimesh, MeshLib, manifold3d, and PrusaSlicer CLI.
-- **Voice:** browser speech recognition or the optional Deepgram STT service.
-- **Persistence:** Firestore metadata and immutable GCS artifacts in managed
-  production; local filesystem is only a development cache.
+[Try the hosted alpha](https://3d.pulsai.app) ·
+[Roadmap](ROADMAP.md) ·
+[Contributing](CONTRIBUTING.md) ·
+[Share feedback](https://github.com/gizmuf/voice-to-3d-print/issues/new/choose)
 
-## Architecture Flow
-1. The user starts with text, voice, an image reference, or imported CAD/mesh.
-2. Deterministic parameter edits run locally; harder requests use the CAD agent
-   only when the customer supplies a key or platform spend is explicitly enabled.
-3. Audited CAD source builds in an isolated, resource-limited subprocess.
-4. A successful revision persists source, parameters, mesh hash, STEP/STL/GLB,
-   and the current preview atomically.
-5. Manufacturability checks gate slicing; PrusaSlicer produces FDM G-code for
-   models that pass the configured profile's hard checks.
+Pulsai 3D lets you start from a description, a template, or an existing CAD
+file; refine the result with parameters or conversation; inspect revisions and
+manufacturability signals; and export STEP, STL, GLB, DXF, or optional FDM
+G-code. The editable build123d/OpenCascade model is the source of truth. Meshes
+and previews are derived artifacts.
 
-## Local Setup
+> **Project status: public alpha.** The deterministic CAD path works without
+> paid AI. The hosted alpha requires Google sign-in, and AI features normally
+> require your own provider key unless account access was explicitly granted.
+> Pulsai 3D is not safety-certified: independently review every model, slicer
+> profile, and G-code file before manufacturing.
 
-The canonical Linux/VPS instructions are in
-[`docs/RUNBOOK_LINUX.md`](docs/RUNBOOK_LINUX.md).
+## Why Pulsai 3D
 
-### 1) Backend
-Python 3.11–3.13 is supported by the current pinned environment.
+- **CAD-first, not mesh-only.** Parametric source, parameters, named features,
+  revisions, and STEP exports remain connected.
+- **Fast edits without an AI bill.** Numeric and deterministic edits run
+  locally; AI is reserved for ambiguous or structural work.
+- **Manufacturing-aware.** FDM and CNC heuristics, printer profiles, slicing,
+  and export bundles live in the same workflow.
+- **Open and self-hostable.** The application is AGPL-licensed, with local
+  development and customer-owned provider keys supported.
+- **Built with explicit safety boundaries.** Generated CAD code is audited and
+  isolated, artifacts are owner-scoped, and platform-paid AI is off by default.
+
+## What works today
+
+| Area | Current capability |
+| --- | --- |
+| Start | Five starter designs, text prompts, build123d source, STEP/STP import, and STL fallback |
+| Edit | Parameters, named-feature edits, full-script revisions, chat, and optional voice input |
+| Inspect | 3D preview, revision history, feature context, and FDM/CNC manufacturability heuristics |
+| Export | STEP, STL, GLB, DXF, FDM bundles, and optional PrusaSlicer G-code |
+| Providers | Deterministic local path plus optional Anthropic, OpenAI, Gemini, Meshy, Tripo, Trellis2, and TripoSR integrations |
+| Operations | Linux CI, secret scanning, owner isolation, private artifacts, backup/restore guidance, and a free CAD-to-print E2E |
+
+STEP is the preferred editable interchange format. Imported STEP solids can be
+transformed and augmented, but Pulsai does not promise perfect reconstruction
+of every upstream feature tree. STL is a triangle mesh and has more limited
+editability.
+
+## Try it in five minutes
+
+### Hosted alpha — no coding
+
+1. Open [3d.pulsai.app](https://3d.pulsai.app) in Chrome or Safari.
+2. Sign in with Google so projects and files stay private to your account.
+3. Choose an example prompt such as the phone stand, speaker grille, pen holder,
+   or box, then create the model.
+4. Change one numeric parameter and confirm the preview and revision change.
+5. Export a file if the workflow is useful to you.
+6. [Report what worked or failed](https://github.com/gizmuf/voice-to-3d-print/issues/new/choose).
+
+AI-assisted edits may ask for a provider key. You can still test starter
+designs, deterministic parameter edits, previews, and much of the export flow
+without a paid model call. See the
+[non-coder testing guide](docs/HELP_WITHOUT_CODING.md) for a 10-minute checklist.
+
+### Local development
+
+Prerequisites: Git, Python 3.12, Node.js 22, and optionally PrusaSlicer for
+G-code generation.
 
 ```bash
+git clone https://github.com/gizmuf/voice-to-3d-print.git
+cd voice-to-3d-print
+
 cd backend
 python3 -m venv .venv
-source .venv/bin/activate
-pip install -r requirements.txt
+.venv/bin/python -m pip install --upgrade pip
+.venv/bin/python -m pip install -r requirements-dev.txt
+PULSAI_AUTH_REQUIRED=false \
+PULSAI_INSECURE_LOCAL_DEV=true \
+PULSAI_PUBLIC_SAFE_MODE=true \
+.venv/bin/python -m uvicorn app:app --host 127.0.0.1 --port 8000
 ```
 
-Set env vars (copy from `backend/.env.example`):
+In a second terminal:
+
 ```bash
-cp .env.example .env
+cd voice-to-3d-print/frontend
+npm ci
+NEXT_PUBLIC_BACKEND_URL=http://127.0.0.1:8000 npm run dev
 ```
 
-Run FastAPI:
-```bash
-uvicorn app:app --reload --port 8000
+Open [http://localhost:3000/design](http://localhost:3000/design). No provider
+key is required for the deterministic starter-design path. For pinned Linux
+dependencies, STT setup, production-safe configuration, and the full validation
+gate, use [`docs/RUNBOOK_LINUX.md`](docs/RUNBOOK_LINUX.md).
+
+## Architecture
+
+```text
+Next.js / React / Three.js
+          |
+          v
+FastAPI API and owner-scoped project store
+          |
+          v
+Audited build123d/OpenCascade CAD subprocess
+          |
+          +--> STEP / STL / GLB / DXF revisions
+          +--> manufacturability checks
+          +--> optional PrusaSlicer G-code
 ```
 
-### 2) Frontend
-```bash
-cd ../frontend
-npm install
-npm run dev
-```
+Harder natural-language edits can use a provider-backed agent. The agent calls
+bounded CAD tools; successful builds persist source, parameters, mesh hashes,
+and artifacts as a revision. Failed audits or builds do not silently replace
+the last valid model.
 
-Open http://localhost:3000
+Useful technical references:
 
-## Notes
-- **Cheapest defaults:** `THREED_PROVIDER=parametric` and deterministic parameter edits; both avoid paid model calls.
-- **PrusaSlicer:** Set `PRUSASLICER_PATH` and `PRUSASLICER_CONFIG` in `.env`.
-- **Provider switching:** Set `THREED_PROVIDER=meshy`, `THREED_PROVIDER=tripo`, `THREED_PROVIDER=parametric`, `THREED_PROVIDER=trellis2`, or `THREED_PROVIDER=triposr`.
-- **Legacy Gemini proxy:** There is no default. If enabled for compatibility,
-  it must be owned by this stack and remains subject to the platform-spend gate.
-- **Deepgram STT (optional):** Set `DEEPGRAM_API_KEY` to enable server transcription from recorded audio.
-- **Model library option:** Add GLB links to `backend/data/model_library.json` for local catalog search.
-- **Sketchfab search (optional):** Set `SKETCHFAB_API_TOKEN` to search downloadable models and retrieve GLB links.
-- **Onshape import (optional):** Set `ONSHAPE_ACCESS_KEY` + `ONSHAPE_SECRET_KEY` for server-side STEP import from pasted Onshape Part Studio / Assembly URLs. OAuth config is scaffolded for the public multi-user version.
-- **Image to model:** `/generate-image` supports Meshy, Tripo, Trellis2, and TripoSR (set `provider` query param).
-- **Trellis2 API:** Set `TRELLIS2_API_URL` plus `TRELLIS2_IMAGE_ENDPOINT` to enable image-to-3D via a Trellis2 GPU service. Text-to-3D requires a custom `TRELLIS2_TEXT_ENDPOINT`.
-- **TripoSR local:** Set `TRIPOSR_ROOT` (path to the TripoSR repo) and optionally `TRIPOSR_CACHE_DIR` (e.g. an external drive). TripoSR is image-to-3D only and runs on CPU if no CUDA GPU is present.
-
-## Local TripoSR (Optional GPU Worker)
-
-TripoSR is disabled in the baseline and is not required for CAD, preview, or
-slicing. If a dedicated GPU worker is approved later, clone it outside this
-checkout, create an isolated environment, and configure `TRIPOSR_ROOT`,
-`TRIPOSR_CACHE_DIR`, and `TRIPOSR_PYTHON` with VPS/worker-local paths. Do not
-make a laptop checkout or an unrelated product repository a runtime dependency.
-
-## Endpoints
-
-**Code-driven CAD engine (powerful path):**
-- `GET /design/templates` → list seed scripts
-- `POST /design/create` → create a new design from `prompt` / `template_id` / `script` (audits + sandbox-builds an initial STL+GLB)
-- `GET /design/{id}` → get the design (script, parameters, named features, latest build)
-- `GET /design` → list saved designs
-- `POST /design/{id}/chat` → SSE chat with Pulsai (powerful tool set, no capability matrix)
-- `GET /design/{id}/conversation` → persisted chat history
-- `POST /design/{id}/build` → re-run with optional STL/STEP/DXF/GLB targets, optional G-code slice
-
-**Legacy template path (kept for compat, scheduled for removal):**
-- `POST /generate`, `POST /process-model`, `POST /generate-image?provider=…` → legacy generation
-- `POST /workspace/{id}/chat` (legacy capability-matrix agent), `GET /workspace/{id}/conversation`,
-  `GET /workspace/{id}/editability`, `POST /workspace/{id}/export-bundle`,
-  `GET /workspace/{id}/export-bundle/dry-run` — narrowed to numeric param tweaks on fixed templates.
-
-**Common:**
-- `GET /artifacts/...` → static artifact serving
-- `GET /printer-profiles` → list available printer profiles
-- `GET /integrations/onshape/status` → check Onshape config
-- `POST /integrations/onshape/import-step` → export STEP from an Onshape Part Studio / Assembly URL and import it as a Pulsai design
-
-## The Pulsai Design Studio (powerful)
-
-Frontend route: **`/design`** (open `http://localhost:3000/design`).
-
-Each "design" *is* a [build123d](https://github.com/gumyr/build123d) Python
-script. Parameters are declared via the runner-provided `pulsai.param()`
-helper; named feature blocks delimited by `# @feature: name` ... `# @end`
-are independently editable by the agent. The script is the source of truth;
-the inspector (parameters / features / manufacturability) is a derived view.
-
-### Chat tools (no capability matrix, no per-template gating)
-
-| Tool | Purpose |
-| --- | --- |
-| `read_design` | Return current script, parameters, features, and last-build summary. |
-| `query_library` | Search the snippet library (holes, polygons, patterns, fillets, shells, …). |
-| `update_parameter` | Fast path for numeric tweaks — re-run the script with one override. |
-| `replace_feature` | Surgically swap the body of a `# @feature: name` block. |
-| `append_feature` | Add a new feature block. |
-| `rewrite_design` | Full script replacement (escape hatch). |
-| `run_build` | Execute and emit STL/STEP/DXF/GLB; optional G-code slice. |
-| `check_manufacturability` | Process-aware (`fdm` or `cnc`) report. |
-
-Refusals come from the **AST audit** (security: no `os`, `subprocess`, network,
-`exec`/`eval`, `__class__.__mro__`, etc.) and from real **sandbox build
-failures** — not from a hand-coded matrix.
-
-### Sandboxing
-
-Every script runs in a separate Python subprocess:
-
-- **AST audit** (`services/codegen/ast_audit.py`) parses the script and
-  rejects unsafe imports, dunder access, exec/eval, file/network APIs.
-- **Subprocess** (`services/codegen/sandbox.py`) launches with a stripped
-  environment (no `ANTHROPIC_API_KEY` etc.), `cwd=/tmp/job_id`, no
-  `PYTHONPATH` injection, `python -I` (isolated mode).
-- **Resource limits** (`services/codegen/runner/host.py`) apply
-  `RLIMIT_CPU = 90s`, `RLIMIT_AS = 4 GiB` before importing build123d.
-- **Wall-clock timeout** = 120 s, after which the subprocess is hard-killed
-  by `subprocess.run`.
-- **Cloud Run** already uses gVisor; on macOS dev the above + the runner's
-  isolated mode are the layers.
-
-### Manufacturability — process-aware
-
-`check_mesh(mesh, profile, process)` produces a `ManufacturabilityReport`:
-
-- **FDM**: overhangs > 45°, sampled inward-ray min wall thickness, watertight
-  + winding consistency, bed-size fit (per printer profile).
-- **CNC**: undercuts (faces with `n.z < -0.1`), sharp internal corners
-  (heuristic on adjacent face angles), watertightness, stock-size fit.
-
-### Outputs
-
-STL, GLB, **STEP** (CNC handoff), **DXF** (2D / waterjet / laser), G-code (FDM
-via PrusaSlicer when `slice_gcode=true`).
-
-### Snippet library
-
-Pre-baked build123d idioms in `services/codegen/library/__init__.py`:
-circular hole, **polygon hole** (triangle, hex, …), slot, circular pattern,
-grid pattern, **hex grid**, fillet, chamfer, shell open-top, counterbore,
-boss with hole, rounded box. Searchable via `query_library(intent)`.
-
-## Phase 1: Pulsai chat agent
-
-The new agent loop replaces the legacy single-prompt `/workspace/{id}/ai-edit`
-path. It uses the Anthropic SDK directly (no proxy), calls a fixed set of
-tools, and is gated by a per-template/source capability matrix.
-
-### Required env vars
-
-```
-ANTHROPIC_API_KEY=sk-ant-...
-ANTHROPIC_CHAT_MODEL=claude-sonnet-5
-ANTHROPIC_CLASSIFY_MODEL=claude-haiku-4-5-20251001  # used in Phase 2 routing
-ANTHROPIC_FALLBACK_MODEL=claude-sonnet-4-6
-ANTHROPIC_MAX_OUTPUT_TOKENS=1500
-OPENAI_API_KEY=sk-...                               # optional jewelry concept generation
-OPENAI_IMAGE_MODEL=gpt-image-1.5
-DEFAULT_PRINTER_PROFILE_ID=prusa_mk4_default
-```
-
-`GEMINI_PROXY_URL` remains supported but is *legacy-only* and has no default.
-If used, it must point to a runtime owned by this 3D Stack; another product is
-never a dependency or credential source.
-
-### Provider reliability and customer BYOK
-
-Transient 429/5xx/529 failures use bounded exponential backoff with jitter,
-`Retry-After`, a circuit breaker, and `ANTHROPIC_FALLBACK_MODEL`. The browser
-can optionally send the customer's own Anthropic key for a CAD turn. The studio
-also accepts OpenAI, Gemini, Meshy, and Tripo keys for concept, intent/image,
-and organic-mesh tasks. Unsaved drafts stay in the current tab's memory. An
-authenticated user may explicitly save them; the backend stores only
-account-bound encrypted ciphertext and never returns the values. Only the
-selected provider key is sent. BYOK never silently falls back to a Pulsai
-platform key.
-
-See `docs/SECURITY_AND_SECRETS.md`, `docs/RUNBOOK_LINUX.md`, and
-`docs/PRODUCTION_RUNBOOK.md` for Cloud Run Secret Manager verification, the
-canonical VPS setup, and the no-traffic production release procedure.
-
-### Tools available to the agent
-
-| Tool | Purpose |
-| --- | --- |
-| `mutate_parameter` | Change one parameter on one feature. Validated against the capability matrix; refuses silent no-ops. |
-| `add_feature` / `remove_feature` | Always refused in Phase 1; refusals carry a clear suggestion. Phase 2 will lift this. |
-| `run_preview` | Rebuild GLB/STL, return revision id + mesh hash. |
-| `check_manufacturability` | Mesh-based: min wall, overhangs, watertightness, bed fit. |
-| `query_tree` | Read-only feature lookup. |
-
-### Editability levels
-
-Every workspace ships with a backend-enforced `EditabilityAssessment`
-(`GET /workspace/{id}/editability`). The four levels are:
-
-- **editable** — full parametric tree, all tools available.
-- **partially_editable** — recognized features editable, opaque parts move with the model.
-- **reference_only** — unrecognized imports; export is `as_is`, no geometry edits.
-- **locked_unsafe** — manufacturability flagged the model invalid; export blocked until repair.
-
-The same assessment populates the `EditabilityBadge` shown next to the model
-name in the inspector.
-
-### Upload format guidance
-
-For editable CAD handoff, ask designers for **STEP/STP**. STEP preserves
-solid/B-rep topology, so Pulsai can load it as `imported_part` and apply
-build123d transforms, boolean cuts, mounting holes, and additive features.
-Use **STL** for final print meshes only; STL is triangles, so edits are limited
-to reconstruction, mesh booleans, repair, and reference workflows.
-
-The preferred endpoint is `POST /design/import-cad`. The older
-`POST /design/import-stl` route remains as a backward-compatible alias.
-
-### CAD integrations
-
-See `docs/CAD_INTEGRATIONS.md`. Current direction: **Onshape first** for direct
-cloud CAD import, **Fusion STEP handoff first** with optional local Fusion MCP
-bridge later. No CAD account or desktop install should be required for the core
-maker flow.
-
-### Printer profiles
-
-The studio ships a curated FDM profile registry in
-`backend/services/printer_profiles.py` covering common Prusa, Bambu, Voron,
-Creality, Elegoo, Anycubic, and generic 0.4mm printers. Profiles drive bed-fit,
-overhang messaging, and slicing defaults. Add new curated profiles there; user
-custom/imported profiles should stay data-driven rather than hardcoded into UI
-components. If a user's exact printer is missing, pick the closest bed/nozzle
-match or the Generic 0.4mm FDM profile; this changes printability estimates and
-slicer defaults, not the CAD geometry itself.
-
-### ZIP export bundle
-
-`POST /workspace/{id}/export-bundle` returns a manifest URL pointing at
-`bundle.zip` containing:
-
-- `model.stl` (or `preview.stl` for reference-only exports)
-- `model.glb`
-- `output.gcode` (skipped for reference-only)
-- `manifest.json` — `{ model_name, revision_id, exported_at, source, editability_level, export_mode, printer_profile, parameter_values, manufacturability_report, mesh_hash, validation, software_version }`
-
-The endpoint requires `expected_revision_id` and rejects with HTTP 409 if the
-caller's expected revision is stale. This is the revision-truth guarantee:
-exports always match what the user just saw in the viewer, never an older
-preview.
+- [`docs/EDITING_PIPELINE.md`](docs/EDITING_PIPELINE.md)
+- [`docs/CAD_INTEGRATIONS.md`](docs/CAD_INTEGRATIONS.md)
+- [`docs/SECURITY_AND_SECRETS.md`](docs/SECURITY_AND_SECRETS.md)
+- [`SECURITY.md`](SECURITY.md)
+- [Detailed product roadmap](docs/ROADMAP.md)
 
 ## Tests
 
-```
-backend/tests/contracts/test_editability.py            # fast unit, no heavy deps
-backend/tests/contracts/test_capability_matrix.py      # needs trimesh + cadquery
-backend/tests/contracts/test_mesh_hash_changes.py      # opt-in: RUN_MESH_HASH_CONTRACTS=1
-backend/tests/ai/evals/                                # ANTHROPIC_API_KEY required
-frontend/tests/e2e/killer-flow.spec.ts                 # Playwright E2E
+The GitHub Actions workflow runs backend tests, frontend tests/lint/build, STT
+security tests, dependency auditing, secret scanning, and a free browser
+CAD-to-print flow. The current main branch is expected to keep that workflow
+green.
+
+For local checks:
+
+```bash
+cd backend
+.venv/bin/python -m pytest -q tests \
+  --ignore=tests/ai/evals/test_eval_runner.py \
+  --ignore=tests/ai/evals_v2/test_eval_runner_v2.py
+
+cd ../frontend
+npm run test:unit
+npm run lint
+npm run build
 ```
 
-Frontend Playwright setup:
+Live provider evals are intentionally excluded because they can incur cost.
+Run them only with an explicit budget and your own authorized credentials.
 
-```
-cd frontend
-npm install              # picks up @playwright/test
-npm run test:e2e:install # one-time browser install
-npm run test:e2e
-```
+## Contributing
 
-## Repo Structure
-```
-backend/
-  app.py
-  config.py
-  requirements.txt
-  services/
-    generation.py
-    gemini_intent.py
-    library.py
-  slicer_service.py
-frontend/
-  app/
-  components/
-  styles/
-```
+You do not need to be a CAD expert or a programmer. Useful contributions
+include testing the hosted alpha, writing reproducible bug reports, improving
+docs, adding printer profiles, and working on issues labeled
+[`good first issue`](https://github.com/gizmuf/voice-to-3d-print/labels/good%20first%20issue).
 
-## License and user designs
+Read [`CONTRIBUTING.md`](CONTRIBUTING.md) before opening a pull request. Please
+report security issues privately using [`SECURITY.md`](SECURITY.md).
+
+## License, user files, and commercial use
 
 The application source is licensed under **GNU AGPL-3.0-or-later**; see
-[`LICENSE`](LICENSE). If you run a modified version as a network service, the
-AGPL generally requires offering its users the corresponding source code for
-that modified service. It does not, by itself, require users to publish the CAD
-models, prompts, images, STL/STEP files, or G-code they create with Pulsai 3D.
+[`LICENSE`](LICENSE). If you offer a modified version over a network, the AGPL
+generally requires offering the corresponding source of that modified service
+to its users.
 
-“Pulsai” names and logos are not licensed as trademarks. Commercial licensing
-for organizations that cannot use AGPL can be offered separately by the
-copyright holder. This summary is practical project guidance, not legal advice.
+The license does not, by itself, require users to publish the CAD models,
+prompts, images, exports, or G-code they create with Pulsai 3D. The “Pulsai”
+names and logos are not granted as trademarks. A managed hosted service and
+separate commercial licensing can coexist with the open-source project. This
+paragraph is practical project guidance, not legal advice.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,62 @@
+# Pulsai 3D public roadmap
+
+Pulsai 3D is a public alpha. The near-term goal is not feature count; it is a
+short, trustworthy path from an idea to an editable and reviewable
+manufacturing file.
+
+## Shipped in v0.1
+
+- build123d/OpenCascade source-of-truth CAD with isolated execution;
+- five starter designs and deterministic parameter editing;
+- conversational edits with customer-owned provider keys;
+- STEP/STP and STL import with explicit editability limits;
+- STEP, STL, GLB, DXF, and optional FDM G-code exports;
+- revision history, mesh hashes, and manufacturability heuristics;
+- private, owner-scoped hosted projects and artifacts;
+- Linux CI, secret scanning, security policy, and a free CAD-to-print E2E;
+- AGPL-3.0-or-later community edition.
+
+## Now — first-user reliability
+
+- make a fresh local install reproducible for new contributors;
+- collect feedback from real maker, CAD, and non-CAD workflows;
+- turn recurring feedback into small, testable issues;
+- improve empty states, error messages, and no-key deterministic paths;
+- publish small alpha releases with honest limitations and verification notes.
+
+## Next — useful breadth
+
+- more starter designs and hardware vocabulary;
+- clearer STEP/STL editability explanations and import diagnostics;
+- broader printer-profile coverage with contributor-friendly tests;
+- accessibility and keyboard-flow improvements;
+- one-command local development without weakening secure defaults;
+- stable headless contracts for a future CLI, Python SDK, and MCP adapter.
+
+## Later — sustainable product
+
+- richer revision comparison and collaboration;
+- managed queues, storage, backups, and team workspaces;
+- expanded manufacturing checks and process handoff packages;
+- optional hosted compute and commercial licensing for organizations that
+  cannot use AGPL;
+- a public design/gallery ecosystem with explicit opt-in publishing.
+
+## Explicit non-goals
+
+- claiming that generated models or G-code are universally safe;
+- pretending arbitrary STL meshes recover a full parametric feature tree;
+- hiding provider costs or silently spending a platform key;
+- making customer models public by default;
+- treating heuristic CNC checks as CAM or machine-ready toolpaths.
+
+## How priorities are chosen
+
+User evidence beats speculative scope. Priority increases when an issue is
+reproducible, affects the core **describe → edit → inspect → export** loop, and
+can be verified without paid-provider ambiguity. Public issues and releases
+will record that maintenance work.
+
+The longer engineering plan and decision history remain in
+[`docs/ROADMAP.md`](docs/ROADMAP.md). They are planning material, not a promise
+of dates or delivery order.

--- a/docs/HELP_WITHOUT_CODING.md
+++ b/docs/HELP_WITHOUT_CODING.md
@@ -1,0 +1,89 @@
+# Help Pulsai 3D without coding
+
+You do not need to install anything, fork the repository, or understand CAD.
+The most valuable help is one real attempt followed by specific feedback.
+
+## Ten-minute test
+
+1. Open [3d.pulsai.app](https://3d.pulsai.app) in Chrome or Safari.
+2. Sign in with Google. Your projects and files should stay private to your
+   account.
+3. Pick an example you understand, such as the phone stand, speaker grille,
+   pen holder, or box, then create the model.
+4. Change one visible number, such as width, height, or hole diameter.
+5. Confirm that the 3D preview changes and that a new revision appears.
+6. Try one export format if it is useful to you. Do not manufacture or print a
+   file without reviewing it in your normal CAD/slicer workflow.
+7. Submit feedback through the
+   [GitHub issue chooser](https://github.com/gizmuf/voice-to-3d-print/issues/new/choose).
+
+AI-assisted editing may request a provider key. You can stop there and still
+report the experience; you are not expected to buy anything to help test the
+free deterministic path.
+
+## What to report
+
+A useful report answers five questions:
+
+- What were you trying to make or change?
+- Which starter model or uploaded file did you use?
+- What exact step did you take?
+- What did you expect, and what actually happened?
+- Which device and browser did you use?
+
+A screenshot helps, but remove email addresses, provider keys, private model
+names, customer data, and anything else you would not post publicly. For a
+security or privacy problem, use the private route in [`SECURITY.md`](../SECURITY.md).
+
+## Stars and sharing
+
+If you genuinely find the project useful or want to follow it, starring the
+[GitHub repository](https://github.com/gizmuf/voice-to-3d-print) is welcome. A
+star is optional and should reflect real interest. Do not fork the repository
+unless you actually plan to work with the code.
+
+The strongest support is to share Pulsai 3D with one maker, designer, engineer,
+or 3D-printing user who has a real part to try. Ask them for the same short test
+and honest feedback.
+
+---
+
+# Jak pomóc Pulsai 3D bez programowania
+
+Nie musisz nic instalować, forkować repozytorium ani znać CAD. Najcenniejsza
+pomoc to jedna prawdziwa próba i konkretny feedback.
+
+## Test w 10 minut
+
+1. Otwórz [3d.pulsai.app](https://3d.pulsai.app) w Chrome lub Safari.
+2. Zaloguj się przez Google. Projekty i pliki powinny pozostać prywatne dla
+   Twojego konta.
+3. Wybierz zrozumiały przykład: stojak na telefon, maskownicę głośnika,
+   pojemnik na długopisy albo pudełko, a następnie utwórz model.
+4. Zmień jedną widoczną wartość, np. szerokość, wysokość lub średnicę otworu.
+5. Sprawdź, czy zmienił się podgląd 3D i pojawiła się nowa rewizja.
+6. Jeśli ma to sens, spróbuj eksportu. Nie drukuj ani nie produkuj pliku bez
+   sprawdzenia go w swoim zwykłym CAD-zie lub slicerze.
+7. Przekaż feedback przez
+   [formularz GitHub](https://github.com/gizmuf/voice-to-3d-print/issues/new/choose).
+
+Edycja przez AI może poprosić o klucz dostawcy. Możesz wtedy przerwać i nadal
+opisać doświadczenie — nie oczekujemy, że kupisz cokolwiek, aby przetestować
+bezpłatną ścieżkę deterministyczną.
+
+## Co napisać
+
+- Co próbowałeś zrobić lub zmienić?
+- Którego modelu startowego albo pliku użyłeś?
+- Jaki dokładnie krok wykonałeś?
+- Czego oczekiwałeś, a co się stało?
+- Jakiego urządzenia i przeglądarki użyłeś?
+
+Zrzut ekranu pomaga, ale usuń adres e-mail, klucze API, prywatne nazwy modeli i
+dane klientów. Problem bezpieczeństwa lub prywatności zgłoś prywatnie według
+[`SECURITY.md`](../SECURITY.md).
+
+Jeżeli projekt naprawdę Ci się podoba lub chcesz go obserwować, możesz dać mu
+gwiazdkę na [GitHubie](https://github.com/gizmuf/voice-to-3d-print). Gwiazdka
+jest dobrowolna i powinna oznaczać prawdziwe zainteresowanie. Nie rób forka,
+jeśli nie planujesz pracować z kodem.

--- a/docs/LAUNCH_PLAN.md
+++ b/docs/LAUNCH_PLAN.md
@@ -1,0 +1,74 @@
+# Minimal open-source launch plan
+
+The goal of the first launch is evidence, not vanity metrics: real attempts,
+reproducible feedback, and a small amount of external participation.
+
+## Success signals for the first 14 days
+
+- 10 people complete at least one real hosted-demo workflow;
+- 5 useful feedback reports describe an expected and actual result;
+- 2 developers complete a fresh local setup;
+- 1 external documentation, test, profile, or code pull request;
+- 1 model is reviewed in a real maker workflow, with limitations recorded;
+- every public issue receives triage and a clear next state.
+
+Stars and forks are observed but are not targets. Do not trade, buy, or request
+empty engagement.
+
+## Day 0 — make the project reviewable
+
+- publish the v0.1.0 alpha release and its known limitations;
+- keep CI green and ensure the README demo/setup links work;
+- open several genuinely scoped `good first issue` tasks;
+- verify that bug and non-coder feedback forms are available;
+- prepare one short demo clip later if a clean, non-private workflow is ready.
+
+## Days 1–3 — personal tests
+
+Invite 10–15 people individually across four groups:
+
+- makers or 3D-printing users with a real small part in mind;
+- CAD/build123d/Python developers who can evaluate architecture or setup;
+- AI/developer-tool users who can assess the agent workflow;
+- non-CAD users who can expose onboarding and language problems.
+
+Ask each person for one concrete action: a 10-minute hosted test, a local
+install, or review of one issue. Do not ask everyone to star or fork. Reply to
+feedback quickly and convert repeated problems into public issues.
+
+## Days 4–7 — one focused public launch
+
+After the first private feedback is addressed, publish one clear post in one
+relevant community. Lead with a real workflow and the technical distinction:
+editable CAD source and revisions rather than only a generated mesh. Include:
+
+- a one-sentence problem and audience;
+- a short demo or before/after model;
+- hosted alpha and source links;
+- the alpha limitations;
+- one explicit request for feedback on the core workflow.
+
+Good launch formats include a Show HN post, a relevant maker/3D-printing
+community, or an AI-CAD developer community. Use one first, answer every useful
+comment, and only cross-post after incorporating what was learned.
+
+## Days 8–14 — show maintenance
+
+- triage every issue and close duplicates respectfully;
+- merge small external improvements with visible review and checks;
+- publish v0.1.1 only if there are meaningful fixes;
+- record anonymized, verifiable adoption evidence: completed tests, external
+  contributors, resolved issues, releases, or documented real workflows;
+- use that evidence in grant applications without inflating users or reach.
+
+## Outreach message
+
+> I am testing Pulsai 3D, an open-source parametric CAD studio that turns a
+> description or starter model into editable CAD and manufacturing files. Could
+> you spend 10 minutes changing one starter model and tell me exactly where the
+> workflow is confusing or fails? No coding, fork, purchase, or positive review
+> is expected. Demo: https://3d.pulsai.app — source:
+> https://github.com/gizmuf/voice-to-3d-print
+
+For developers, replace the hosted-test request with: “Could you try the local
+quick start and report the first point where a fresh checkout fails?”

--- a/docs/OPEN_SOURCE_STRATEGY.md
+++ b/docs/OPEN_SOURCE_STRATEGY.md
@@ -77,6 +77,6 @@ external users or contributors.
 Current status: repository `gizmuf/voice-to-3d-print` is public under
 AGPL-3.0-or-later. History and staged secret scans passed before publication,
 documented public-safe defaults are in place, and CI covers backend, frontend,
-STT, secret scanning, and a free CAD-to-print flow. The next OSS gate is the
-v0.1.0 alpha release, followed by real-user feedback, public issue triage, and
-small external contributions.
+STT, secret scanning, and a free CAD-to-print flow. The v0.1.0 alpha release is
+the first public milestone. The next gates are real-user feedback, public issue
+triage, and small external contributions.

--- a/docs/OPEN_SOURCE_STRATEGY.md
+++ b/docs/OPEN_SOURCE_STRATEGY.md
@@ -74,6 +74,9 @@ external users or contributors.
 - Publish a clean tagged release from a reviewed commit, then change GitHub
   visibility. Do not expose the current working tree directly.
 
-Current status: repository `gizmuf/voice-to-3d-print` is private and now has an
-AGPL-3.0-or-later license. It must not be made public until the remaining
-history/secret/security/CI release gate passes.
+Current status: repository `gizmuf/voice-to-3d-print` is public under
+AGPL-3.0-or-later. History and staged secret scans passed before publication,
+documented public-safe defaults are in place, and CI covers backend, frontend,
+STT, secret scanning, and a free CAD-to-print flow. The next OSS gate is the
+v0.1.0 alpha release, followed by real-user feedback, public issue triage, and
+small external contributions.


### PR DESCRIPTION
## What changed

- rewrites the README around a clear public-alpha position, hosted demo, honest limitations, and a reproducible local quick start
- replaces the contribution blocker with a practical contributor workflow and explicit licensing boundary
- adds a concise public roadmap and v0.1.0 changelog
- adds English/Polish non-coder testing instructions and a minimal 14-day launch plan
- adds structured bug, feature, and non-coder feedback forms plus a pull request template
- updates stale public/private status in the OSS strategy

## Why

Pulsai 3D is public and actively maintained, but the repository front page was too technical for first-time users and the old contribution policy effectively blocked external code. This change makes the project easier to try, evaluate, and contribute to without overstating adoption or manufacturing safety.

## Impact

New users get a five-minute path. Non-coders can provide useful feedback without forking. Contributors get scoped entry points. Maintainers get visible issue-triage and release artifacts appropriate for an honest public-alpha launch.

## Validation

- `git diff --check`
- all GitHub issue-form YAML parsed successfully
- all relative Markdown links in the new public docs resolve locally
- hosted alpha returns HTTP 307 to `/design` and HTTP 200
- current `main` CI is green; this PR will run the full repository workflow
- no paid model calls or production changes