### PR TITLE
Audit backend Python dependencies in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,11 +30,15 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install --yes libgl1 libglib2.0-0 libgomp1 prusa-slicer
-      - name: Install Python dependencies
+      - name: Install Python dependencies and audit tools
         working-directory: backend
         run: |
           python -m pip install --upgrade pip
-          python -m pip install -r requirements-dev.txt
+          python -m pip install -r requirements-dev.txt pip-audit
+          python -m pip check
+      - name: Audit backend dependencies
+        working-directory: backend
+        run: python -m pip_audit -r requirements.txt
       - name: Verify Python and shell sources
         run: |
           python -m compileall -q backend/app.py backend/config.py backend/services backend/tests


### PR DESCRIPTION
## Summary

Add the same dependency-vulnerability gate to the main backend that already exists for the frontend and STT service.

### Changes
- install `pip-audit` in the backend CI job
- run `python -m pip check` after installation
- reject known vulnerabilities in `backend/requirements.txt` with `python -m pip_audit -r requirements.txt`

## Why

The repository currently audits npm dependencies and STT Python dependencies, but the main FastAPI/CAD backend dependency lock was not checked for published vulnerabilities. This closes that coverage gap.

If the new audit finds a vulnerable pinned dependency, CI should fail visibly so the dependency can be upgraded deliberately.