### PR TITLE
Add browser coverage for bilingual pre-login auth

### DIFF
--- a/frontend/tests/e2e/auth-embedded-browser.spec.ts
+++ b/frontend/tests/e2e/auth-embedded-browser.spec.ts
@@ -1,11 +1,11 @@
-import { expect, test } from "@playwright/test";
+import { expect, test, type Page } from "@playwright/test";
 
 test.use({
   userAgent:
     "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 Codex/1.0 Electron/37",
 });
 
-test("Google login is popup-compatible and explains embedded-browser fallback", async ({ page }) => {
+async function mockUnauthenticatedGoogle(page: Page) {
   await page.route("http://localhost:8000/auth/config", async (route) => {
     await route.fulfill({
       status: 200,
@@ -42,9 +42,38 @@ test("Google login is popup-compatible and explains embedded-browser fallback", 
       `,
     });
   });
+}
+
+test("Google login is popup-compatible and explains embedded-browser fallback in English", async ({ page }) => {
+  await mockUnauthenticatedGoogle(page);
 
   const response = await page.goto("/design");
   expect(response?.headers()["cross-origin-opener-policy"]).toBe("same-origin-allow-popups");
   await expect(page.getByRole("button", { name: "Continue with Google" })).toBeVisible();
-  await expect(page.getByRole("note")).toContainText("Open in external browser");
+  await expect(page.getByText("Sign in with Google so your projects and files remain private to your account.")).toBeVisible();
+  await expect(page.getByRole("note")).toContainText("This is an embedded browser.");
+  await expect(page.getByRole("link", { name: "Privacy" })).toHaveAttribute("href", "/privacy");
+  await expect(page.getByRole("link", { name: "Terms" })).toHaveAttribute("href", "/terms");
+  await expect(page.getByRole("link", { name: "Source" })).toHaveAttribute("href", "https://github.com/gizmuf/voice-to-3d-print");
+});
+
+test("Google login is readable in Polish for a Polish browser locale", async ({ page }) => {
+  await page.addInitScript(() => {
+    Object.defineProperty(window.navigator, "language", { configurable: true, value: "pl-PL" });
+    Object.defineProperty(window.navigator, "languages", { configurable: true, value: ["pl-PL", "pl"] });
+  });
+  await mockUnauthenticatedGoogle(page);
+
+  await page.goto("/design");
+  await expect(page.getByText("Zaloguj się przez Google, aby projekty i pliki były widoczne tylko dla Ciebie.")).toBeVisible();
+  await expect(page.getByRole("note")).toContainText("To jest przeglądarka osadzona.");
+  await expect(page.getByRole("link", { name: "Privacy" })).toHaveAttribute("href", "/privacy");
+});
+
+test("Google login honors a stored UI language preference", async ({ page }) => {
+  await page.addInitScript(() => window.localStorage.setItem("pulsai:ui-language", "pl"));
+  await mockUnauthenticatedGoogle(page);
+
+  await page.goto("/design");
+  await expect(page.getByText("Zaloguj się przez Google, aby projekty i pliki były widoczne tylko dla Ciebie.")).toBeVisible();
 });


### PR DESCRIPTION
## Summary

Follow-up regression coverage for #9, whose implementation was merged in #14.

Fixes #9.

## What was wrong

The bilingual pre-login implementation had no browser coverage for an English browser locale, a Polish browser locale, or an existing stored UI-language preference. That left its acceptance criteria vulnerable to regression.

## What changed

- Refactored the existing Google-auth browser setup into a reusable mock helper.
- Added Chrome browser coverage for English pre-login copy and embedded-browser guidance.
- Added coverage for Polish browser locale handling.
- Added coverage that stored `pulsai:ui-language=pl` takes precedence.
- Asserted that Google, privacy, terms, and source links remain available with their existing destinations.

## Tests performed

- `PLAYWRIGHT_CHANNEL=chrome npx playwright test tests/e2e/auth-embedded-browser.spec.ts --project=chromium` — 3 passed.
- `npm run test:unit` — 13 passed.
- `npm run lint` — passed with 67 existing repository warnings and no errors.
- `npm run build` — passed.

## Browser verification

Chrome-backed Playwright verification used only mocked local auth endpoints; no live provider calls were made.

- `en-US` without a stored preference rendered English sign-in and embedded-browser guidance.
- `pl-PL` without a stored preference rendered Polish sign-in and embedded-browser guidance.
- A stored `pulsai:ui-language=pl` preference rendered Polish before login.