### PR TITLE
Harden and smoke-test the production backend container

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.12"
+          python-version: "3.13"
           cache: pip
           cache-dependency-path: backend/requirements*.txt
       - name: Install system dependencies
@@ -50,6 +50,38 @@ jobs:
           python -m pytest -q tests \
             --ignore=tests/ai/evals/test_eval_runner.py \
             --ignore=tests/ai/evals_v2/test_eval_runner_v2.py
+
+  container-smoke:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    needs: backend
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build production backend image
+        run: docker build --tag pulsai-backend:ci backend
+      - name: Run container as non-root and verify health
+        run: |
+          docker run --detach --name pulsai-backend-smoke \
+            --publish 18080:8080 \
+            --env PULSAI_AUTH_REQUIRED=false \
+            --env PULSAI_INSECURE_LOCAL_DEV=true \
+            --env PULSAI_PUBLIC_SAFE_MODE=true \
+            --env PULSAI_ALLOW_PLATFORM_AI_SPEND=false \
+            pulsai-backend:ci
+          trap 'docker logs pulsai-backend-smoke || true; docker rm --force pulsai-backend-smoke || true' EXIT
+          test "$(docker exec pulsai-backend-smoke id -u)" != "0"
+          for attempt in {1..90}; do
+            if curl -fsS http://127.0.0.1:18080/health >/dev/null; then
+              exit 0
+            fi
+            if ! docker inspect --format '{{.State.Running}}' pulsai-backend-smoke | grep -qx true; then
+              docker logs pulsai-backend-smoke
+              exit 1
+            fi
+            sleep 1
+          done
+          docker logs pulsai-backend-smoke
+          exit 1
 
   frontend:
     runs-on: ubuntu-24.04
@@ -129,7 +161,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.12"
+          python-version: "3.13"
           cache: pip
           cache-dependency-path: backend/requirements*.txt
       - uses: actions/setup-node@v4

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,9 +1,9 @@
 FROM python:3.13-slim
 
-ENV PYTHONUNBUFFERED=1 \
-    PIP_NO_CACHE_DIR=1
-
-WORKDIR /app
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PORT=8080 \
+    HOME=/home/pulsai
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
@@ -13,10 +13,17 @@ RUN apt-get update \
         prusa-slicer \
     && rm -rf /var/lib/apt/lists/*
 
-COPY requirements.txt .
-RUN python -m pip install --upgrade pip \
-    && python -m pip install -r requirements.txt
-
+WORKDIR /app
+COPY requirements.txt ./requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt
 COPY . .
 
+RUN addgroup --system pulsai \
+    && adduser --system --ingroup pulsai --home /home/pulsai pulsai \
+    && mkdir -p /app/data/output /app/data/telemetry \
+    && chown -R pulsai:pulsai /app/data/output /app/data/telemetry /home/pulsai
+
+USER pulsai
+
+EXPOSE 8080
 CMD ["sh", "-c", "uvicorn app:app --host 0.0.0.0 --port ${PORT:-8080}"]


### PR DESCRIPTION
## Summary

Closes #19 by aligning CI with the production runtime and testing the actual container rather than source processes only.

### Docker hardening
- run the backend as an unprivileged `pulsai` user
- keep only runtime output/telemetry directories writable
- provide a real home directory for tools that require one
- expose the production port explicitly

### CI coverage
- run the backend and CAD-to-print E2E jobs on Python 3.13, matching the Docker image and `.python-version`
- build the production backend image in CI
- verify the container process UID is non-root
- start the image with local-safe settings and smoke `/health`
- retain backend dependency auditing, full free tests, frontend, STT security, E2E and secret scan

## Validation

CI is the validation gate for the Docker build, non-root runtime, container health, Python 3.13 backend suite and browser CAD-to-print flow.