### PR TITLE
Add baseline frontend security response headers

### DIFF
--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -14,6 +14,22 @@ const nextConfig = {
             key: "Referrer-Policy",
             value: "strict-origin-when-cross-origin",
           },
+          {
+            key: "X-Content-Type-Options",
+            value: "nosniff",
+          },
+          {
+            key: "X-Frame-Options",
+            value: "DENY",
+          },
+          {
+            key: "Permissions-Policy",
+            value: "camera=(), geolocation=(), microphone=(self)",
+          },
+          {
+            key: "Content-Security-Policy",
+            value: "base-uri 'self'; object-src 'none'; frame-ancestors 'none'",
+          },
         ],
       },
     ];


### PR DESCRIPTION
## Summary

Refs #23 by adding low-risk response hardening that should remain compatible with Google Sign-In and the current inline-styled UI.

### Added
- `X-Content-Type-Options: nosniff`
- `X-Frame-Options: DENY`
- `Permissions-Policy` denying camera/geolocation and limiting microphone to same-origin
- a baseline CSP restricting `base-uri`, plugins/objects and framing

### Preserved
- `Cross-Origin-Opener-Policy: same-origin-allow-popups` for Google Sign-In
- existing referrer policy
- current redirects and application behavior

This deliberately does not introduce broad `script-src`, `style-src` or `connect-src` directives yet; those require hosted login/backend-origin testing to avoid breaking Google Identity Services and configurable API endpoints.

CI frontend tests, lint and production build are the initial validation gate.