### PR TITLE
Add CodeQL scanning for Python and JavaScript

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,40 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: "23 4 * * 2"
+
+permissions:
+  contents: read
+  security-events: write
+  packages: read
+  actions: read
+
+concurrency:
+  group: codeql-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        language:
+          - javascript-typescript
+          - python
+    steps:
+      - uses: actions/checkout@v4
+      - uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: none
+      - uses: github/codeql-action/analyze@v3
+        with:
+          category: /language:${{ matrix.language }}


### PR DESCRIPTION
## Summary

Add repository-wide CodeQL analysis for the two primary codebases:

- Python backend/STT/CAD services
- JavaScript/TypeScript frontend

The workflow runs on `main`, pull requests and a weekly schedule, with separate language jobs and security-events permissions limited to the scanner.

## Why

Pulsai already has dependency audits, secret scanning and tests. CodeQL adds semantic code scanning for data-flow, injection and other implementation-level vulnerability patterns that those checks do not cover.

Any alerts should be triaged on their actual exploitability rather than merged or dismissed automatically.