### PR TITLE
Configure weekly Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,62 @@
+version: 2
+updates:
+  - package-ecosystem: pip
+    directory: /backend
+    schedule:
+      interval: weekly
+      day: monday
+      time: "05:00"
+      timezone: Etc/UTC
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+      - python
+    groups:
+      backend-patch-and-minor:
+        update-types:
+          - minor
+          - patch
+
+  - package-ecosystem: pip
+    directory: /stt-service
+    schedule:
+      interval: weekly
+      day: monday
+      time: "05:15"
+      timezone: Etc/UTC
+    open-pull-requests-limit: 3
+    labels:
+      - dependencies
+      - python
+    groups:
+      stt-patch-and-minor:
+        update-types:
+          - minor
+          - patch
+
+  - package-ecosystem: npm
+    directory: /frontend
+    schedule:
+      interval: weekly
+      day: monday
+      time: "05:30"
+      timezone: Etc/UTC
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+    groups:
+      frontend-patch-and-minor:
+        update-types:
+          - minor
+          - patch
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "05:45"
+      timezone: Etc/UTC
+    open-pull-requests-limit: 3
+    labels:
+      - dependencies


### PR DESCRIPTION
## Summary

Configure Dependabot for:

- backend Python dependencies
- STT-service Python dependencies
- frontend npm dependencies
- GitHub Actions

Patch and minor updates are grouped by component to reduce PR noise. Major updates remain separate for deliberate review.

## Why

The repository already rejects known vulnerabilities in CI, but update discovery should also be automated so pinned dependencies and CI actions do not drift indefinitely.