### PR TITLE
Fail closed on unsafe production startup configuration

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -26,4 +26,4 @@ RUN addgroup --system pulsai \
 USER pulsai
 
 EXPOSE 8080
-CMD ["sh", "-c", "uvicorn app:app --host 0.0.0.0 --port ${PORT:-8080}"]
+CMD ["sh", "-c", "uvicorn production_app:app --host 0.0.0.0 --port ${PORT:-8080}"]

--- a/backend/production_app.py
+++ b/backend/production_app.py
@@ -1,0 +1,18 @@
+"""Production ASGI entrypoint with fail-closed configuration validation."""
+
+from __future__ import annotations
+
+import os
+
+from config import settings
+from services.runtime_validation import validate_production_settings
+
+
+validate_production_settings(settings, os.environ)
+
+# Import only after validation so an unsafe deployment never initializes the
+# API, provider clients, artifact directories, or a healthy endpoint.
+from app import app  # noqa: E402
+
+
+__all__ = ["app"]

--- a/backend/services/runtime_validation.py
+++ b/backend/services/runtime_validation.py
@@ -1,0 +1,109 @@
+"""Fail-closed validation for network production deployments.
+
+The checks in this module intentionally run before FastAPI accepts traffic.
+Local development and CI remain unaffected unless they explicitly identify
+as production through ``K_SERVICE`` or ``PULSAI_ENVIRONMENT=production``.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+from urllib.parse import urlsplit
+
+from cryptography.fernet import Fernet
+
+
+_PRODUCTION_NAMES = frozenset({"prod", "production"})
+_TRUE_VALUES = frozenset({"1", "true", "yes", "on"})
+
+
+def is_production_environment(environ: Mapping[str, str]) -> bool:
+    """Return whether this process is intended to serve production traffic."""
+    explicit = environ.get("PULSAI_ENVIRONMENT", "").strip().lower()
+    return explicit in _PRODUCTION_NAMES or bool(environ.get("K_SERVICE", "").strip())
+
+
+def _env_enabled(environ: Mapping[str, str], name: str) -> bool:
+    return environ.get(name, "").strip().lower() in _TRUE_VALUES
+
+
+def _valid_https_origins(raw: str) -> bool:
+    origins = [origin.strip().rstrip("/") for origin in raw.split(",") if origin.strip()]
+    if not origins:
+        return False
+    for origin in origins:
+        parsed = urlsplit(origin)
+        if (
+            origin in {"*", "null"}
+            or parsed.scheme != "https"
+            or not parsed.netloc
+            or parsed.path not in {"", "/"}
+            or parsed.query
+            or parsed.fragment
+        ):
+            return False
+    return True
+
+
+def production_configuration_errors(
+    settings: Any,
+    environ: Mapping[str, str],
+) -> list[str]:
+    """Return non-secret-bearing descriptions of unsafe production settings."""
+    if not is_production_environment(environ):
+        return []
+
+    errors: list[str] = []
+    if not settings.auth_required:
+        errors.append("PULSAI_AUTH_REQUIRED must be true")
+    if settings.insecure_local_dev:
+        errors.append("PULSAI_INSECURE_LOCAL_DEV must be false")
+    if not settings.google_oauth_client_id.strip():
+        errors.append("GOOGLE_OAUTH_CLIENT_ID must be configured")
+    if not _valid_https_origins(settings.cors_origins):
+        errors.append("CORS_ORIGINS must contain explicit HTTPS origins")
+    if settings.allow_untrusted_cad_code:
+        errors.append("PULSAI_ALLOW_UNTRUSTED_CAD_CODE must be false")
+    if settings.allow_platform_ai_spend:
+        errors.append("PULSAI_ALLOW_PLATFORM_AI_SPEND must be false")
+    if settings.allow_public_artifacts:
+        errors.append("PULSAI_ALLOW_PUBLIC_ARTIFACTS must be false")
+    if not settings.firebase_project_id.strip():
+        errors.append("FIREBASE_PROJECT_ID must be configured for durable state")
+
+    encryption_key = settings.byok_encryption_key.strip()
+    if not encryption_key:
+        errors.append("PULSAI_BYOK_ENCRYPTION_KEY must be configured")
+    else:
+        try:
+            Fernet(encryption_key.encode("ascii"))
+        except (ValueError, UnicodeEncodeError):
+            errors.append("PULSAI_BYOK_ENCRYPTION_KEY must be a valid Fernet key")
+
+    if _env_enabled(environ, "PULSAI_DURABLE_ARTIFACTS"):
+        if not settings.firebase_storage_bucket.strip():
+            errors.append(
+                "FIREBASE_STORAGE_BUCKET is required when PULSAI_DURABLE_ARTIFACTS is true"
+            )
+
+    return errors
+
+
+def validate_production_settings(
+    settings: Any,
+    environ: Mapping[str, str],
+) -> None:
+    """Raise before startup when a production deployment is unsafe."""
+    errors = production_configuration_errors(settings, environ)
+    if errors:
+        raise RuntimeError(
+            "Unsafe Pulsai production configuration: " + "; ".join(errors)
+        )
+
+
+__all__ = [
+    "is_production_environment",
+    "production_configuration_errors",
+    "validate_production_settings",
+]

--- a/backend/services/runtime_validation.py
+++ b/backend/services/runtime_validation.py
@@ -59,6 +59,8 @@ def production_configuration_errors(
         errors.append("PULSAI_AUTH_REQUIRED must be true")
     if settings.insecure_local_dev:
         errors.append("PULSAI_INSECURE_LOCAL_DEV must be false")
+    if not settings.public_safe_mode:
+        errors.append("PULSAI_PUBLIC_SAFE_MODE must be true")
     if not settings.google_oauth_client_id.strip():
         errors.append("GOOGLE_OAUTH_CLIENT_ID must be configured")
     if not _valid_https_origins(settings.cors_origins):

--- a/backend/tests/test_runtime_validation.py
+++ b/backend/tests/test_runtime_validation.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+from cryptography.fernet import Fernet
+
+from services.runtime_validation import (
+    is_production_environment,
+    production_configuration_errors,
+    validate_production_settings,
+)
+
+
+def _valid_settings(**overrides):
+    values = {
+        "auth_required": True,
+        "insecure_local_dev": False,
+        "google_oauth_client_id": "google-web-client.apps.googleusercontent.com",
+        "cors_origins": "https://3d.pulsai.app",
+        "allow_untrusted_cad_code": False,
+        "allow_platform_ai_spend": False,
+        "allow_public_artifacts": False,
+        "firebase_project_id": "pulsai-app",
+        "firebase_storage_bucket": "pulsai-app.appspot.com",
+        "byok_encryption_key": Fernet.generate_key().decode("ascii"),
+    }
+    values.update(overrides)
+    return SimpleNamespace(**values)
+
+
+def test_local_and_ci_environments_are_not_subject_to_production_gate() -> None:
+    unsafe = _valid_settings(
+        auth_required=False,
+        insecure_local_dev=True,
+        google_oauth_client_id="",
+    )
+
+    assert not is_production_environment({})
+    assert production_configuration_errors(unsafe, {}) == []
+    validate_production_settings(unsafe, {})
+
+
+def test_cloud_run_and_explicit_production_are_detected() -> None:
+    assert is_production_environment({"K_SERVICE": "pulsai-3d-backend"})
+    assert is_production_environment({"PULSAI_ENVIRONMENT": "production"})
+    assert is_production_environment({"PULSAI_ENVIRONMENT": "PROD"})
+
+
+def test_valid_cloud_run_configuration_passes() -> None:
+    validate_production_settings(
+        _valid_settings(),
+        {
+            "K_SERVICE": "pulsai-3d-backend",
+            "PULSAI_DURABLE_ARTIFACTS": "true",
+        },
+    )
+
+
+@pytest.mark.parametrize(
+    ("overrides", "expected"),
+    [
+        ({"auth_required": False}, "PULSAI_AUTH_REQUIRED"),
+        ({"insecure_local_dev": True}, "PULSAI_INSECURE_LOCAL_DEV"),
+        ({"google_oauth_client_id": ""}, "GOOGLE_OAUTH_CLIENT_ID"),
+        ({"cors_origins": "*"}, "CORS_ORIGINS"),
+        ({"cors_origins": "http://3d.pulsai.app"}, "CORS_ORIGINS"),
+        ({"allow_untrusted_cad_code": True}, "PULSAI_ALLOW_UNTRUSTED_CAD_CODE"),
+        ({"allow_platform_ai_spend": True}, "PULSAI_ALLOW_PLATFORM_AI_SPEND"),
+        ({"allow_public_artifacts": True}, "PULSAI_ALLOW_PUBLIC_ARTIFACTS"),
+        ({"firebase_project_id": ""}, "FIREBASE_PROJECT_ID"),
+        ({"byok_encryption_key": ""}, "PULSAI_BYOK_ENCRYPTION_KEY"),
+        ({"byok_encryption_key": "not-a-fernet-key"}, "valid Fernet key"),
+    ],
+)
+def test_unsafe_production_settings_are_rejected(overrides, expected) -> None:
+    with pytest.raises(RuntimeError, match=expected):
+        validate_production_settings(
+            _valid_settings(**overrides),
+            {"K_SERVICE": "pulsai-3d-backend"},
+        )
+
+
+def test_durable_artifact_mode_requires_a_bucket() -> None:
+    errors = production_configuration_errors(
+        _valid_settings(firebase_storage_bucket=""),
+        {
+            "K_SERVICE": "pulsai-3d-backend",
+            "PULSAI_DURABLE_ARTIFACTS": "true",
+        },
+    )
+
+    assert errors == [
+        "FIREBASE_STORAGE_BUCKET is required when PULSAI_DURABLE_ARTIFACTS is true"
+    ]
+
+
+def test_error_message_never_contains_secret_value() -> None:
+    bad_secret = "sensitive-but-invalid-secret-value"
+
+    with pytest.raises(RuntimeError) as exc_info:
+        validate_production_settings(
+            _valid_settings(byok_encryption_key=bad_secret),
+            {"K_SERVICE": "pulsai-3d-backend"},
+        )
+
+    assert bad_secret not in str(exc_info.value)

--- a/backend/tests/test_runtime_validation.py
+++ b/backend/tests/test_runtime_validation.py
@@ -16,6 +16,7 @@ def _valid_settings(**overrides):
     values = {
         "auth_required": True,
         "insecure_local_dev": False,
+        "public_safe_mode": True,
         "google_oauth_client_id": "google-web-client.apps.googleusercontent.com",
         "cors_origins": "https://3d.pulsai.app",
         "allow_untrusted_cad_code": False,
@@ -33,6 +34,7 @@ def test_local_and_ci_environments_are_not_subject_to_production_gate() -> None:
     unsafe = _valid_settings(
         auth_required=False,
         insecure_local_dev=True,
+        public_safe_mode=False,
         google_oauth_client_id="",
     )
 
@@ -62,6 +64,7 @@ def test_valid_cloud_run_configuration_passes() -> None:
     [
         ({"auth_required": False}, "PULSAI_AUTH_REQUIRED"),
         ({"insecure_local_dev": True}, "PULSAI_INSECURE_LOCAL_DEV"),
+        ({"public_safe_mode": False}, "PULSAI_PUBLIC_SAFE_MODE"),
         ({"google_oauth_client_id": ""}, "GOOGLE_OAUTH_CLIENT_ID"),
         ({"cors_origins": "*"}, "CORS_ORIGINS"),
         ({"cors_origins": "http://3d.pulsai.app"}, "CORS_ORIGINS"),

--- a/docs/PRODUCTION_STARTUP_VALIDATION.md
+++ b/docs/PRODUCTION_STARTUP_VALIDATION.md
@@ -17,6 +17,7 @@ Local development and ordinary CI imports remain unchanged.
 A production process must have:
 
 - authentication enabled and insecure local mode disabled;
+- public safe mode enabled so legacy/unsafe routes remain unavailable;
 - a Google OAuth web client ID;
 - explicit HTTPS CORS origins, never `*` or `null`;
 - untrusted CAD execution disabled;

--- a/docs/PRODUCTION_STARTUP_VALIDATION.md
+++ b/docs/PRODUCTION_STARTUP_VALIDATION.md
@@ -1,0 +1,52 @@
+# Production startup validation
+
+The production backend image starts `production_app:app`, not `app:app`.
+`production_app.py` validates deployment invariants before importing the FastAPI
+application. A failed check terminates the process before `/health` can become
+available.
+
+The gate runs when either:
+
+- Cloud Run sets `K_SERVICE`; or
+- `PULSAI_ENVIRONMENT=production` (or `prod`) is set explicitly.
+
+Local development and ordinary CI imports remain unchanged.
+
+## Required invariants
+
+A production process must have:
+
+- authentication enabled and insecure local mode disabled;
+- a Google OAuth web client ID;
+- explicit HTTPS CORS origins, never `*` or `null`;
+- untrusted CAD execution disabled;
+- platform-funded AI spend disabled;
+- public artifacts disabled;
+- a Firebase project for durable design state;
+- a valid Fernet key for encrypted account BYOK storage;
+- a storage bucket when `PULSAI_DURABLE_ARTIFACTS=true`.
+
+Validation messages name settings only. They must never include credential
+values, filesystem contents, or stack traces.
+
+## Local verification
+
+The normal local entrypoint remains:
+
+```bash
+PULSAI_AUTH_REQUIRED=false \
+PULSAI_INSECURE_LOCAL_DEV=true \
+PULSAI_PUBLIC_SAFE_MODE=true \
+python -m uvicorn app:app --host 127.0.0.1 --port 8000
+```
+
+To exercise the production gate without serving traffic, provide production-like
+environment values and import the production entrypoint:
+
+```bash
+PULSAI_ENVIRONMENT=production python -c 'import production_app'
+```
+
+Use placeholder identifiers only in a disposable environment. Never paste real
+secret values into shell history; production secrets must remain Secret Manager
+references as described in `docs/PRODUCTION_RUNBOOK.md`.


### PR DESCRIPTION
## Summary

Closes #18 by adding one explicit, testable production startup gate before the FastAPI application is imported.

### Production behavior
- Cloud Run (`K_SERVICE`) and explicit `PULSAI_ENVIRONMENT=production|prod` activate validation
- the backend container now starts `production_app:app`
- unsafe configuration terminates the process before `/health` can become available
- local development and ordinary CI continue to use `app:app` unchanged

### Validated invariants
- authentication enabled and insecure-local mode disabled
- public safe mode enabled so unsafe/legacy routes remain blocked
- Google OAuth client configured
- explicit HTTPS CORS origins
- untrusted CAD execution disabled
- platform AI spend disabled
- public artifacts disabled
- Firebase project configured for durable state
- valid Fernet key for encrypted account BYOK credentials
- storage bucket configured whenever durable artifacts are enabled

### Regression protection
- focused unit tests for local no-op, Cloud Run detection, a valid production configuration, every fail-closed setting, durable-artifact bucket requirements and secret-redaction behavior
- production container smoke remains the integration gate
- validation errors contain setting names only, never credential values
- the P1 review finding about disabled public safe mode is covered directly by validation and a regression test

### Documentation
Adds `docs/PRODUCTION_STARTUP_VALIDATION.md` describing activation, invariants and safe local verification.

This PR must not merge until the updated CI, CodeQL and review thread are clean.