### PR TITLE
Publish the v0.1.0 public-alpha GitHub Release

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -1,0 +1,81 @@
+name: Publish GitHub release
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - docs/releases/v0.1.0.md
+      - .github/workflows/publish-release.yml
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Existing Git tag to publish or refresh
+        required: true
+        default: v0.1.0
+      notes_file:
+        description: Repository-relative Markdown release notes path
+        required: true
+        default: docs/releases/v0.1.0.md
+      title:
+        description: GitHub Release title
+        required: true
+        default: Pulsai 3D v0.1.0 — First Public Alpha
+
+permissions:
+  contents: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Resolve release inputs
+        id: release
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          INPUT_TAG: ${{ inputs.tag }}
+          INPUT_NOTES_FILE: ${{ inputs.notes_file }}
+          INPUT_TITLE: ${{ inputs.title }}
+        run: |
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            tag="$INPUT_TAG"
+            notes_file="$INPUT_NOTES_FILE"
+            title="$INPUT_TITLE"
+          else
+            tag="v0.1.0"
+            notes_file="docs/releases/v0.1.0.md"
+            title="Pulsai 3D v0.1.0 — First Public Alpha"
+          fi
+
+          test -n "$tag"
+          test -f "$notes_file"
+          git rev-parse --verify "refs/tags/$tag"
+
+          {
+            echo "tag=$tag"
+            echo "notes_file=$notes_file"
+            echo "title=$title"
+          } >> "$GITHUB_OUTPUT"
+      - name: Publish or refresh the release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ steps.release.outputs.tag }}
+          NOTES_FILE: ${{ steps.release.outputs.notes_file }}
+          TITLE: ${{ steps.release.outputs.title }}
+        run: |
+          if gh release view "$TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            gh release edit "$TAG" \
+              --repo "$GITHUB_REPOSITORY" \
+              --title "$TITLE" \
+              --notes-file "$NOTES_FILE" \
+              --latest
+          else
+            gh release create "$TAG" \
+              --repo "$GITHUB_REPOSITORY" \
+              --verify-tag \
+              --title "$TITLE" \
+              --notes-file "$NOTES_FILE" \
+              --latest
+          fi

--- a/docs/releases/v0.1.0.md
+++ b/docs/releases/v0.1.0.md
@@ -27,10 +27,10 @@ This is an alpha release and is not safety-certified for manufacturing. Imported
 
 ## Documentation
 
-- [README and quick start](../../README.md)
-- [Contributing](../../CONTRIBUTING.md)
-- [Security policy](../../SECURITY.md)
-- [Linux runbook](../RUNBOOK_LINUX.md)
-- [Changelog](../../CHANGELOG.md)
+- [README and quick start](https://github.com/gizmuf/voice-to-3d-print/blob/v0.1.0/README.md)
+- [Contributing](https://github.com/gizmuf/voice-to-3d-print/blob/v0.1.0/CONTRIBUTING.md)
+- [Security policy](https://github.com/gizmuf/voice-to-3d-print/blob/v0.1.0/SECURITY.md)
+- [Linux runbook](https://github.com/gizmuf/voice-to-3d-print/blob/v0.1.0/docs/RUNBOOK_LINUX.md)
+- [Changelog](https://github.com/gizmuf/voice-to-3d-print/blob/v0.1.0/CHANGELOG.md)
 
 License: AGPL-3.0-or-later.

--- a/docs/releases/v0.1.0.md
+++ b/docs/releases/v0.1.0.md
@@ -1,0 +1,36 @@
+# Pulsai 3D v0.1.0 — First Public Alpha
+
+Pulsai 3D is an open-source, AI-first parametric CAD and 3D-print preparation environment built around build123d and OpenCascade.
+
+## Included in this alpha
+
+- parametric Design Studio with starter models and deterministic edits;
+- revision-aware previews and exports;
+- STEP/STP and STL import paths;
+- STEP, STL, GLB, DXF and bundle exports;
+- optional FDM G-code through PrusaSlicer;
+- FDM/CNC manufacturability heuristics and printer profiles;
+- owner-scoped authentication, private artifacts and BYOK provider routing;
+- public-safe defaults, CI, secret scanning and contribution documentation.
+
+## Free deterministic path
+
+The repository can be evaluated without a paid AI-provider call by using the built-in templates/examples, changing numeric parameters and exporting the result.
+
+## Hosted alpha
+
+A hosted alpha is available at https://3d.pulsai.app. Availability and provider-backed features may vary; self-hosting remains supported.
+
+## Important limitations
+
+This is an alpha release and is not safety-certified for manufacturing. Imported STEP feature trees and arbitrary STL meshes are not fully reconstructable in every case. AI and organic-mesh output varies by provider. Every model, printer profile, toolpath and G-code file requires independent review before manufacture.
+
+## Documentation
+
+- [README and quick start](../../README.md)
+- [Contributing](../../CONTRIBUTING.md)
+- [Security policy](../../SECURITY.md)
+- [Linux runbook](../RUNBOOK_LINUX.md)
+- [Changelog](../../CHANGELOG.md)
+
+License: AGPL-3.0-or-later.


### PR DESCRIPTION
## Summary

Closes #27 by making the first public-alpha GitHub Release reproducible and source-controlled.

### Added
- reviewed release notes at `docs/releases/v0.1.0.md`
- an idempotent release workflow with `contents: write`
- automatic publication from the existing `v0.1.0` tag after this PR reaches `main`
- manual `workflow_dispatch` inputs for deliberately refreshing a future existing tag from a reviewed notes file

### Safety and repeatability
- verifies that the tag already exists before publishing
- never creates or moves a tag
- updates an existing Release instead of duplicating it
- publishes no binaries, local artifacts, credentials or private CAD files
- uses stable links pinned to the `v0.1.0` source snapshot

### Release positioning
The notes clearly identify this as a public alpha, document the deterministic/no-paid-AI evaluation path, link the hosted alpha, and retain the manufacturing-safety disclaimer.

CI and CodeQL remain the merge gate. After merge, the `Publish GitHub release` workflow should create or refresh the Release object for the existing `v0.1.0` tag.