### PR TITLE
Fix v0.1.0 public-alpha release publishing

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -58,7 +58,7 @@ jobs:
             echo "notes_file=$notes_file"
             echo "title=$title"
           } >> "$GITHUB_OUTPUT"
-      - name: Publish or refresh the release
+      - name: Publish or refresh the public-alpha prerelease
         env:
           GH_TOKEN: ${{ github.token }}
           TAG: ${{ steps.release.outputs.tag }}
@@ -70,12 +70,13 @@ jobs:
               --repo "$GITHUB_REPOSITORY" \
               --title "$TITLE" \
               --notes-file "$NOTES_FILE" \
-              --latest
+              --draft=false \
+              --prerelease
           else
             gh release create "$TAG" \
               --repo "$GITHUB_REPOSITORY" \
               --verify-tag \
               --title "$TITLE" \
               --notes-file "$NOTES_FILE" \
-              --latest
+              --prerelease
           fi


### PR DESCRIPTION
## Summary

Fix the release workflow failure reported by GitHub Actions after #41.

### Root cause

The workflow attempted to mark `v0.1.0` as `--latest` while the release is a draft/prerelease. GitHub rejects that combination with HTTP 422: `Latest release cannot be draft or prerelease.`

### Fix

- keep `v0.1.0` explicitly as a **public-alpha prerelease**;
- when an existing draft/release is found, publish it with `--draft=false --prerelease`;
- when creating it, use `--prerelease`;
- do not force an alpha prerelease to be the repository's `Latest` release.

After this merges, the push-triggered release workflow will rerun automatically because the workflow file itself is in its path filter.