### PR TITLE
Fix alpha release refresh workflow

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -69,13 +69,13 @@ jobs:
             gh release edit "$TAG" \
               --repo "$GITHUB_REPOSITORY" \
               --title "$TITLE" \
-              --notes-file "$NOTES_FILE" \
-              --latest
+              --notes-file "$NOTES_FILE"
           else
             gh release create "$TAG" \
               --repo "$GITHUB_REPOSITORY" \
               --verify-tag \
               --title "$TITLE" \
               --notes-file "$NOTES_FILE" \
-              --latest
+              --prerelease \
+              --latest=false
           fi


### PR DESCRIPTION
The v0.1.0 release is intentionally a prerelease, so GitHub rejects marking it as Latest. Preserve prerelease status when editing it and explicitly create future copies of this alpha as prereleases. This fixes the failed release refresh from run 33390158594.